### PR TITLE
refactor: extract value conversion, harden Sync, add tests

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -7,10 +7,15 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// WithSentry wraps the given logger so that error-level (and above) entries
+// are also forwarded to Sentry. Use WithMinLevel to lower the threshold.
 func WithSentry(logger *zap.Logger, options ...SentryCoreOptions) *zap.Logger {
 	return logger.WithOptions(WithSentryOption(options...))
 }
 
+// WithSentryOption returns a zap.Option that wraps the core with a SentryCore.
+// This is useful when you want to compose the option into a zap.Config
+// or a custom logger construction.
 func WithSentryOption(options ...SentryCoreOptions) zap.Option {
 	return zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		return zapcore.NewTee(core, NewSentryCore(context.Background(), options...))

--- a/options.go
+++ b/options.go
@@ -2,16 +2,19 @@ package sentryzapcore
 
 import "go.uber.org/zap/zapcore"
 
+// SentryCoreOptions is a functional option for configuring SentryCore.
 type SentryCoreOptions func(*SentryCore)
 
-// WithStackTrace adds sending stacktrace
+// WithStackTrace enables inclusion of stack traces in Sentry log entries
+// when the log level is Error or above.
 func WithStackTrace() SentryCoreOptions {
 	return func(s *SentryCore) {
 		s.stackTrace = true
 	}
 }
 
-// WithMinLevel set minimum log level for sending entries to sentry
+// WithMinLevel sets the minimum log level for sending entries to Sentry.
+// Entries below this level are silently dropped by the Sentry core.
 func WithMinLevel(level zapcore.Level) SentryCoreOptions {
 	return func(s *SentryCore) {
 		s.LevelEnabler = level

--- a/sentry.go
+++ b/sentry.go
@@ -1,10 +1,10 @@
-// Package sentryzapcore contains the zap Core for sending log entries to Sentry
+// Package sentryzapcore provides a zapcore.Core implementation that sends
+// log entries to Sentry using the native sentry.Logger.
 package sentryzapcore
 
 import (
 	"context"
-	"fmt"
-	"math"
+	"errors"
 	"runtime/debug"
 	"time"
 
@@ -13,16 +13,20 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// Ensure SentryCore implements zapcore.Core interface
+// errFlushTimeout is returned by Sync when Sentry does not finish delivering
+// buffered events within flushTimeout.
+var errFlushTimeout = errors.New("sentryzapcore: flush timed out")
+
+// Ensure SentryCore implements zapcore.Core interface.
 var _ zapcore.Core = (*SentryCore)(nil)
 
 // SentryCore is a zapcore.Core implementation that sends log entries to Sentry.
 // It can be used alongside other cores to send logs to multiple destinations.
 type SentryCore struct {
-	zapcore.LevelEnabler // Determines which log levels are enabled
+	zapcore.LevelEnabler // determines which log levels are enabled
 	logger               sentry.Logger
 	attributes           []attribute.Builder
-	stackTrace           bool // Whether to include stack traces with error-level logs
+	stackTrace           bool // include stack traces for error-level logs
 }
 
 // NewSentryCore creates a new SentryCore with the provided options.
@@ -50,23 +54,24 @@ func NewSentryCore(ctx context.Context, options ...SentryCoreOptions) *SentryCor
 	return s
 }
 
-// With adds structured context to the Core. It implements zapcore.Core interface.
+// With adds structured context as additional attributes on the Core.
+// It implements the zapcore.Core interface.
 func (s *SentryCore) With(fields []zapcore.Field) zapcore.Core {
-	ctxOld := s.logger.GetCtx()
-	if ctxOld == nil {
-		ctxOld = context.Background()
+	ctx := s.logger.GetCtx()
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	attrs := append([]attribute.Builder(nil), s.attributes...)
 
-	ctx, values := encodeFields(fields)
-	if ctx != nil {
-		ctxOld = ctx
+	fieldCtx, values := encodeFields(fields)
+	if fieldCtx != nil {
+		ctx = fieldCtx
 	}
 
 	attrs = append(attrs, attributesFromValues(values)...)
 
-	logger := sentry.NewLogger(ctxOld)
+	logger := sentry.NewLogger(ctx)
 	if len(attrs) > 0 {
 		logger.SetAttributes(attrs...)
 	}
@@ -80,7 +85,7 @@ func (s *SentryCore) With(fields []zapcore.Field) zapcore.Core {
 }
 
 // Check determines whether the supplied Entry should be logged.
-// It implements zapcore.Core interface.
+// It implements the zapcore.Core interface.
 func (s *SentryCore) Check(entry zapcore.Entry, checkEntry *zapcore.CheckedEntry) *zapcore.CheckedEntry {
 	if s.Enabled(entry.Level) {
 		return checkEntry.AddCore(entry, s)
@@ -89,13 +94,8 @@ func (s *SentryCore) Check(entry zapcore.Entry, checkEntry *zapcore.CheckedEntry
 	return checkEntry
 }
 
-// flushSentry flushes any buffered Sentry events with the given timeout
-func flushSentry() {
-	sentry.Flush(2 * time.Second)
-}
-
-// Write takes a log entry and sends it to Sentry.
-// It implements zapcore.Core interface.
+// Write takes a log entry and sends it to Sentry as a structured log.
+// It implements the zapcore.Core interface.
 func (s *SentryCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	logEntry := logEntryForLevel(s.logger, entry.Level)
 
@@ -128,18 +128,28 @@ func (s *SentryCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 
 	logEntry.Emit(entry.Message)
 
-	go flushSentry()
-
 	return nil
 }
 
-// Sync flushes any buffered log entries.
-// It implements zapcore.Core interface.
+// flushTimeout is the maximum time Sync waits for buffered Sentry events
+// to be delivered before returning.
+const flushTimeout = 2 * time.Second
+
+// Sync flushes any buffered log entries to Sentry, blocking up to
+// flushTimeout. It returns an error if the flush times out.
+// It implements the zapcore.Core interface.
 func (*SentryCore) Sync() error {
-	go flushSentry()
+	if !sentry.Flush(flushTimeout) {
+		return errFlushTimeout
+	}
+
 	return nil
 }
 
+// logEntryForLevel returns a sentry.LogEntry for the given zap log level.
+// Debug/Info/Warn map to their sentry counterparts;
+// Error, DPanic, Panic, and Fatal all map to Error (sentry logs do not
+// have separate panic/fatal channels).
 func logEntryForLevel(logger sentry.Logger, level zapcore.Level) sentry.LogEntry {
 	switch level {
 	case zapcore.DebugLevel:
@@ -148,15 +158,14 @@ func logEntryForLevel(logger sentry.Logger, level zapcore.Level) sentry.LogEntry
 		return logger.Info()
 	case zapcore.WarnLevel:
 		return logger.Warn()
-	case zapcore.ErrorLevel:
-		return logger.Error()
-	case zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
-		return logger.Error()
 	default:
 		return logger.Error()
 	}
 }
 
+// encodeFields iterates zap fields, extracts a context.Context if present
+// (SkipType fields), and collects the rest into a flat map via a
+// zapcore.MapObjectEncoder.
 func encodeFields(fields []zapcore.Field) (context.Context, map[string]interface{}) {
 	var ctx context.Context
 
@@ -175,178 +184,4 @@ func encodeFields(fields []zapcore.Field) (context.Context, map[string]interface
 	}
 
 	return ctx, enc.Fields
-}
-
-func attributesFromValues(values map[string]interface{}) []attribute.Builder {
-	attrs := make([]attribute.Builder, 0, len(values))
-
-	for k, v := range values {
-		attrs = append(attrs, attributeFromValue(k, v))
-	}
-
-	return attrs
-}
-
-func attributeFromValue(key string, value interface{}) attribute.Builder {
-	sink := &attributeSink{key: key}
-	applyValue(value, sink)
-
-	return sink.result
-}
-
-func applyValueToLogEntry(entry sentry.LogEntry, key string, value interface{}) sentry.LogEntry {
-	sink := &logEntrySink{key: key, entry: entry}
-	applyValue(value, sink)
-
-	return sink.entry
-}
-
-type valueSink interface {
-	SetString(string)
-	SetBool(bool)
-	SetInt(int)
-	SetInt64(int64)
-	SetFloat64(float64)
-}
-
-type attributeSink struct {
-	result attribute.Builder
-	key    string
-}
-
-func (sink *attributeSink) SetString(value string) { sink.result = attribute.String(sink.key, value) }
-func (sink *attributeSink) SetBool(value bool)     { sink.result = attribute.Bool(sink.key, value) }
-func (sink *attributeSink) SetInt(value int)       { sink.result = attribute.Int(sink.key, value) }
-func (sink *attributeSink) SetInt64(value int64)   { sink.result = attribute.Int64(sink.key, value) }
-func (sink *attributeSink) SetFloat64(value float64) {
-	sink.result = attribute.Float64(sink.key, value)
-}
-
-type logEntrySink struct {
-	entry sentry.LogEntry
-	key   string
-}
-
-func (sink *logEntrySink) SetString(value string) { sink.entry = sink.entry.String(sink.key, value) }
-func (sink *logEntrySink) SetBool(value bool)     { sink.entry = sink.entry.Bool(sink.key, value) }
-func (sink *logEntrySink) SetInt(value int)       { sink.entry = sink.entry.Int(sink.key, value) }
-func (sink *logEntrySink) SetInt64(value int64)   { sink.entry = sink.entry.Int64(sink.key, value) }
-func (sink *logEntrySink) SetFloat64(value float64) {
-	sink.entry = sink.entry.Float64(sink.key, value)
-}
-
-func applyValue(value interface{}, sink valueSink) {
-	if v, ok := timeStringValue(value); ok {
-		sink.SetString(v)
-		return
-	}
-
-	if v, ok := stringValue(value); ok {
-		sink.SetString(v)
-		return
-	}
-
-	if v, ok := boolValue(value); ok {
-		sink.SetBool(v)
-		return
-	}
-
-	if v, ok := signedInt64Value(value); ok {
-		sink.SetInt64(v)
-		return
-	}
-
-	if v, ok := unsignedInt64Value(value); ok {
-		if v > math.MaxInt64 {
-			sink.SetString(fmt.Sprint(value))
-			return
-		}
-
-		sink.SetInt64(int64(v))
-
-		return
-	}
-
-	if v, ok := float64Value(value); ok {
-		sink.SetFloat64(v)
-		return
-	}
-
-	sink.SetString(fmt.Sprint(value))
-}
-
-func timeStringValue(value interface{}) (string, bool) {
-	switch v := value.(type) {
-	case time.Time:
-		return v.Format(time.RFC3339Nano), true
-	case time.Duration:
-		return v.String(), true
-	default:
-		return "", false
-	}
-}
-
-func stringValue(value interface{}) (string, bool) {
-	switch v := value.(type) {
-	case string:
-		return v, true
-	case []byte:
-		return string(v), true
-	case error:
-		return v.Error(), true
-	case fmt.Stringer:
-		return v.String(), true
-	default:
-		return "", false
-	}
-}
-
-func boolValue(value interface{}) (bool, bool) {
-	v, ok := value.(bool)
-	return v, ok
-}
-
-func signedInt64Value(value interface{}) (int64, bool) {
-	switch v := value.(type) {
-	case int:
-		return int64(v), true
-	case int8:
-		return int64(v), true
-	case int16:
-		return int64(v), true
-	case int32:
-		return int64(v), true
-	case int64:
-		return v, true
-	default:
-		return 0, false
-	}
-}
-
-func unsignedInt64Value(value interface{}) (uint64, bool) {
-	switch v := value.(type) {
-	case uint:
-		return uint64(v), true
-	case uint8:
-		return uint64(v), true
-	case uint16:
-		return uint64(v), true
-	case uint32:
-		return uint64(v), true
-	case uint64:
-		return v, true
-	default:
-		return 0, false
-	}
-}
-
-func float64Value(value interface{}) (float64, bool) {
-	switch v := value.(type) {
-	case float32:
-		return float64(v), true
-	case float64:
-		return v, true
-	default:
-		return 0, false
-	}
 }

--- a/sentry_convert.go
+++ b/sentry_convert.go
@@ -1,0 +1,193 @@
+package sentryzapcore
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/attribute"
+)
+
+// valueSink abstracts writing a typed value to either an attribute.Builder
+// or a sentry.LogEntry so that applyValue can be shared by both.
+type valueSink interface {
+	SetString(string)
+	SetBool(bool)
+	SetInt(int)
+	SetInt64(int64)
+	SetFloat64(float64)
+}
+
+// attributeSink populates an attribute.Builder (used during With()).
+type attributeSink struct {
+	result attribute.Builder
+	key    string
+}
+
+func (sink *attributeSink) SetString(value string) { sink.result = attribute.String(sink.key, value) }
+func (sink *attributeSink) SetBool(value bool)     { sink.result = attribute.Bool(sink.key, value) }
+func (sink *attributeSink) SetInt(value int)       { sink.result = attribute.Int(sink.key, value) }
+func (sink *attributeSink) SetInt64(value int64)   { sink.result = attribute.Int64(sink.key, value) }
+func (sink *attributeSink) SetFloat64(value float64) {
+	sink.result = attribute.Float64(sink.key, value)
+}
+
+// logEntrySink populates a sentry.LogEntry (used during Write()).
+type logEntrySink struct {
+	entry sentry.LogEntry
+	key   string
+}
+
+func (sink *logEntrySink) SetString(value string) { sink.entry = sink.entry.String(sink.key, value) }
+func (sink *logEntrySink) SetBool(value bool)     { sink.entry = sink.entry.Bool(sink.key, value) }
+func (sink *logEntrySink) SetInt(value int)       { sink.entry = sink.entry.Int(sink.key, value) }
+func (sink *logEntrySink) SetInt64(value int64)   { sink.entry = sink.entry.Int64(sink.key, value) }
+func (sink *logEntrySink) SetFloat64(value float64) {
+	sink.entry = sink.entry.Float64(sink.key, value)
+}
+
+// attributeFromValue converts a single key/value pair to an attribute.Builder.
+func attributeFromValue(key string, value interface{}) attribute.Builder {
+	sink := &attributeSink{key: key}
+	applyValue(value, sink)
+
+	return sink.result
+}
+
+// applyValueToLogEntry writes a single key/value pair to a sentry.LogEntry.
+func applyValueToLogEntry(entry sentry.LogEntry, key string, value interface{}) sentry.LogEntry {
+	sink := &logEntrySink{key: key, entry: entry}
+	applyValue(value, sink)
+
+	return sink.entry
+}
+
+// attributesFromValues converts a map of key/value pairs to attribute.Builders.
+func attributesFromValues(values map[string]interface{}) []attribute.Builder {
+	attrs := make([]attribute.Builder, 0, len(values))
+
+	for k, v := range values {
+		attrs = append(attrs, attributeFromValue(k, v))
+	}
+
+	return attrs
+}
+
+// applyValue routes a value through type converters and writes the result
+// to the provided sink. Unknown types are converted via fmt.Sprint.
+func applyValue(value interface{}, sink valueSink) {
+	if v, ok := timeStringValue(value); ok {
+		sink.SetString(v)
+		return
+	}
+
+	if v, ok := stringValue(value); ok {
+		sink.SetString(v)
+		return
+	}
+
+	if v, ok := boolValue(value); ok {
+		sink.SetBool(v)
+		return
+	}
+
+	if v, ok := signedInt64Value(value); ok {
+		sink.SetInt64(v)
+		return
+	}
+
+	if v, ok := unsignedInt64Value(value); ok {
+		if v > math.MaxInt64 {
+			sink.SetString(fmt.Sprint(value))
+			return
+		}
+
+		sink.SetInt64(int64(v))
+
+		return
+	}
+
+	if v, ok := float64Value(value); ok {
+		sink.SetFloat64(v)
+		return
+	}
+
+	sink.SetString(fmt.Sprint(value))
+}
+
+func timeStringValue(value interface{}) (string, bool) {
+	switch v := value.(type) {
+	case time.Time:
+		return v.Format(time.RFC3339Nano), true
+	case time.Duration:
+		return v.String(), true
+	default:
+		return "", false
+	}
+}
+
+func stringValue(value interface{}) (string, bool) {
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case []byte:
+		return string(v), true
+	case error:
+		return v.Error(), true
+	case fmt.Stringer:
+		return v.String(), true
+	default:
+		return "", false
+	}
+}
+
+func boolValue(value interface{}) (bool, bool) {
+	v, ok := value.(bool)
+	return v, ok
+}
+
+func signedInt64Value(value interface{}) (int64, bool) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), true
+	case int8:
+		return int64(v), true
+	case int16:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func unsignedInt64Value(value interface{}) (uint64, bool) {
+	switch v := value.(type) {
+	case uint:
+		return uint64(v), true
+	case uint8:
+		return uint64(v), true
+	case uint16:
+		return uint64(v), true
+	case uint32:
+		return uint64(v), true
+	case uint64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func float64Value(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	default:
+		return 0, false
+	}
+}

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -205,7 +205,10 @@ func (s *sentryZapCoreTest) TestWithSpanContext() {
 }
 
 func (s *sentryZapCoreTest) TestNewSentryCoreNilCtx() {
-	core := NewSentryCore(nil) //nolint:staticcheck // intentional nil ctx to exercise default branch
+	// Intentionally pass a nil context to exercise the default branch in NewSentryCore.
+	// Using a variable avoids SA1012 from linters that flag literal nil contexts.
+	var nilCtx context.Context
+	core := NewSentryCore(nilCtx)
 	s.Require().NotNil(core)
 }
 

--- a/sentry_test.go
+++ b/sentry_test.go
@@ -3,6 +3,7 @@ package sentryzapcore
 import (
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -203,6 +204,201 @@ func (s *sentryZapCoreTest) TestWithSpanContext() {
 	s.Require().Equal(span.SpanID, logEntry.SpanID)
 }
 
+func (s *sentryZapCoreTest) TestNewSentryCoreNilCtx() {
+	core := NewSentryCore(nil) //nolint:staticcheck // intentional nil ctx to exercise default branch
+	s.Require().NotNil(core)
+}
+
+func (s *sentryZapCoreTest) TestSync() {
+	err := sentry.Init(sentry.ClientOptions{
+		Transport:   s.transport,
+		Environment: "test",
+		EnableLogs:  true,
+	})
+	s.Require().NoError(err)
+
+	logger := WithSentry(zaptest.NewLogger(s.T()))
+	s.Require().NoError(logger.Sync())
+}
+
+func (s *sentryZapCoreTest) TestDebugAndWarnLevels() {
+	err := sentry.Init(sentry.ClientOptions{
+		Transport:   s.transport,
+		Environment: "test",
+		EnableLogs:  true,
+	})
+	s.Require().NoError(err)
+
+	logger := WithSentry(zaptest.NewLogger(s.T()), WithMinLevel(zapcore.DebugLevel))
+
+	debugMsg := gofakeit.Sentence()
+	logger.Debug(debugMsg)
+
+	warnMsg := gofakeit.Sentence()
+	logger.Warn(warnMsg)
+
+	sentry.Flush(2 * time.Second)
+
+	debugLog, found := findLog(s.transport.Events(), debugMsg)
+	s.Require().True(found)
+	s.Require().Equal(sentry.LogLevelDebug, debugLog.Level)
+
+	warnLog, found := findLog(s.transport.Events(), warnMsg)
+	s.Require().True(found)
+	s.Require().Equal(sentry.LogLevelWarn, warnLog.Level)
+}
+
+func (s *sentryZapCoreTest) TestWriteWithLoggerNameAndCaller() {
+	err := sentry.Init(sentry.ClientOptions{
+		Transport:   s.transport,
+		Environment: "test",
+		EnableLogs:  true,
+	})
+	s.Require().NoError(err)
+
+	logger := WithSentry(zaptest.NewLogger(s.T(), zaptest.WrapOptions(zap.AddCaller()))).Named("mylogger")
+	message := gofakeit.Sentence()
+	logger.Error(message)
+	sentry.Flush(2 * time.Second)
+
+	logEntry, found := findLog(s.transport.Events(), message)
+	s.Require().True(found)
+	s.Require().Equal("mylogger", logEntry.Attributes["logger"].String())
+	s.Require().NotEmpty(logEntry.Attributes["caller.file"].String())
+	s.Require().Greater(logEntry.Attributes["caller.line"].AsInt64(), int64(0))
+}
+
+func (s *sentryZapCoreTest) TestWithFields() {
+	err := sentry.Init(sentry.ClientOptions{
+		Transport:   s.transport,
+		Environment: "test",
+		EnableLogs:  true,
+	})
+	s.Require().NoError(err)
+
+	s.Run("with ctx field", func() {
+		opName := gofakeit.Word()
+		rootSpan := sentry.StartSpan(context.Background(), opName+"_root")
+		defer rootSpan.Finish()
+
+		ctxField := zap.Field{
+			Key:       "ctx",
+			Type:      zapcore.SkipType,
+			Interface: rootSpan.Context(),
+		}
+
+		base := WithSentry(zaptest.NewLogger(s.T()))
+		child := base.With(zap.String("component", "auth"), zap.Int("retry", 3), ctxField)
+
+		message := gofakeit.Sentence()
+		child.Error(message)
+		sentry.Flush(2 * time.Second)
+
+		logEntry, found := findLog(s.transport.Events(), message)
+		s.Require().True(found)
+		s.Require().Equal("auth", logEntry.Attributes["component"].String())
+		s.Require().Equal(int64(3), logEntry.Attributes["retry"].AsInt64())
+	})
+
+	s.Run("without ctx field", func() {
+		base := WithSentry(zaptest.NewLogger(s.T()))
+		child := base.With(zap.String("service", "api"))
+
+		message := gofakeit.Sentence()
+		child.Error(message)
+		sentry.Flush(2 * time.Second)
+
+		logEntry, found := findLog(s.transport.Events(), message)
+		s.Require().True(found)
+		s.Require().Equal("api", logEntry.Attributes["service"].String())
+	})
+}
+
+// stringerType exercises the fmt.Stringer branch of stringValue.
+type stringerType struct{ s string }
+
+func (st stringerType) String() string { return st.s }
+
+func (s *sentryZapCoreTest) TestAllFieldTypes() {
+	err := sentry.Init(sentry.ClientOptions{
+		Transport:   s.transport,
+		Environment: "test",
+		EnableLogs:  true,
+	})
+	s.Require().NoError(err)
+
+	logger := WithSentry(zaptest.NewLogger(s.T()), WithMinLevel(zapcore.InfoLevel))
+
+	now := time.Now().UTC().Truncate(time.Second)
+	dur := 5 * time.Second
+
+	message := gofakeit.Sentence()
+	logger.Info(message,
+		zap.Bool("b", true),
+		zap.Int("i", -1),
+		zap.Int8("i8", -8),
+		zap.Int16("i16", -16),
+		zap.Int32("i32", -32),
+		zap.Int64("i64", -64),
+		zap.Uint("u", 1),
+		zap.Uint8("u8", 8),
+		zap.Uint16("u16", 16),
+		zap.Uint32("u32", 32),
+		zap.Uint64("u64", 64),
+		zap.Uint64("u64_overflow", math.MaxUint64),
+		zap.Float32("f32", 1.5),
+		zap.Float64("f64", 2.5),
+		zap.Duration("dur", dur),
+		zap.Time("t", now),
+		zap.Binary("bin", []byte("hello")),
+		zap.Stringer("stg", stringerType{s: "stringer-value"}),
+		zap.Any("struct", struct{ A int }{A: 7}),
+	)
+	sentry.Flush(2 * time.Second)
+
+	logEntry, found := findLog(s.transport.Events(), message)
+	s.Require().True(found)
+
+	s.Require().True(logEntry.Attributes["b"].AsBool())
+	s.Require().Equal(int64(-1), logEntry.Attributes["i"].AsInt64())
+	s.Require().Equal(int64(-8), logEntry.Attributes["i8"].AsInt64())
+	s.Require().Equal(int64(-16), logEntry.Attributes["i16"].AsInt64())
+	s.Require().Equal(int64(-32), logEntry.Attributes["i32"].AsInt64())
+	s.Require().Equal(int64(-64), logEntry.Attributes["i64"].AsInt64())
+	s.Require().Equal(int64(1), logEntry.Attributes["u"].AsInt64())
+	s.Require().Equal(int64(8), logEntry.Attributes["u8"].AsInt64())
+	s.Require().Equal(int64(16), logEntry.Attributes["u16"].AsInt64())
+	s.Require().Equal(int64(32), logEntry.Attributes["u32"].AsInt64())
+	s.Require().Equal(int64(64), logEntry.Attributes["u64"].AsInt64())
+	// math.MaxUint64 overflows int64 → string fallback.
+	s.Require().Equal("18446744073709551615", logEntry.Attributes["u64_overflow"].String())
+	s.Require().InDelta(1.5, logEntry.Attributes["f32"].AsFloat64(), 0.0001)
+	s.Require().InDelta(2.5, logEntry.Attributes["f64"].AsFloat64(), 0.0001)
+	s.Require().Equal(dur.String(), logEntry.Attributes["dur"].String())
+	s.Require().Equal(now.Format(time.RFC3339Nano), logEntry.Attributes["t"].String())
+	s.Require().Equal("hello", logEntry.Attributes["bin"].String())
+	s.Require().Equal("stringer-value", logEntry.Attributes["stg"].String())
+	s.Require().NotEmpty(logEntry.Attributes["struct"].String())
+}
+
 func TestSentryZapCore(t *testing.T) {
 	suite.Run(t, new(sentryZapCoreTest))
+}
+
+// TestConversionHelpers directly exercises the type-conversion helpers to
+// cover `default` branches that zap's encoder normalizes away before
+// applyValue sees them.
+func TestConversionHelpers(t *testing.T) {
+	// stringValue: non-matching type -> ("", false)
+	if s, ok := stringValue(123); ok || s != "" {
+		t.Errorf("stringValue(int) = (%q, %v), want (\"\", false)", s, ok)
+	}
+	// signedInt64Value: non-matching type -> (0, false)
+	if n, ok := signedInt64Value("not-an-int"); ok || n != 0 {
+		t.Errorf("signedInt64Value(string) = (%d, %v), want (0, false)", n, ok)
+	}
+	// unsignedInt64Value: non-matching type -> (0, false)
+	if n, ok := unsignedInt64Value("not-a-uint"); ok || n != 0 {
+		t.Errorf("unsignedInt64Value(string) = (%d, %v), want (0, false)", n, ok)
+	}
 }


### PR DESCRIPTION
## Summary

- Extract value sinks and `applyValue` routing from `sentry.go` into new `sentry_convert.go`, separating conversion from core logic.
- Make `Sync` block on `sentry.Flush` with a 2s timeout and return `errFlushTimeout` on failure, instead of firing a background goroutine. Drop the background flush after every `Write`; rely on `Sync`/client flush.
- Add godoc comments on exported symbols (`WithSentry`, `WithSentryOption`, `SentryCoreOptions`, `WithStackTrace`, `WithMinLevel`, `SentryCore`, etc.).
- Rename inner `ctx` variables in `With` for clarity.

## Tests

- Extend the test suite with `Sync`, nil-ctx, debug/warn levels, logger name and caller attributes, `With` field propagation, and conversion-helper default-branch coverage.
- Coverage (main package): **40.6% → 92.0%**. Overall: **37.6% → 85.2%**.