### PR TITLE
docs: add sentry-zapcore agent skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .golangci.yml
+.codex/
+.opencode/
+.claude/
+openspec/changes/archive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Commands
+
+- Test exactly like CI: `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`.
+- Run a focused test: `go test ./... -run TestSentryZapCore/TestWithErrorLog` for testify suite subtests, or `go test ./... -run TestConversionHelpers` for plain tests.
+- Local lint config exists at `.golangci.yml`, but CI replaces it with `https://raw.githubusercontent.com/adlandh/golangci-lint-config/refs/heads/main/.golangci.yml` before running `golangci/golangci-lint-action@v9`. If a lint result matters, check both the repo config and the downloaded CI config.
+- Format with `gofmt`/`goimports`; `.golangci.yml` enables both formatters.
+
+## Repository Shape
+
+- This is a small Go library module, not an app: `module github.com/adlandh/sentry-zapcore/v2`, `go 1.25.0`.
+- Public integration points are `WithSentry`, `WithSentryOption`, `NewSentryCore`, `WithMinLevel`, and `WithStackTrace` in the root package `sentryzapcore`.
+- `example/main.go` is documentation/example code; the linter config excludes `examples$`, but this repo's directory is singular `example`, so do not assume it is excluded locally.
+
+## Implementation Notes
+
+- `SentryCore` is a `zapcore.Core` that tees Zap logs into Sentry's native `sentry.Logger`; default threshold is `zapcore.ErrorLevel`.
+- A `zapcore.SkipType` field whose `Interface` is a non-nil `context.Context` is treated specially as Sentry span context and is not emitted as a normal attribute.
+- `With(fields)` converts Zap fields into persistent Sentry attributes; `Write(entry, fields)` applies per-entry fields and maps Zap debug/info/warn/error+ levels to Sentry log levels.
+- `Sync` calls global `sentry.Flush` with the package `flushTimeout` constant (`2 * time.Second`) and returns `errFlushTimeout` on failure.
+- Attribute conversion intentionally stringifies `time.Time`, `time.Duration`, `[]byte`, `error`, `fmt.Stringer`, unknown structs, and uint64 values larger than `math.MaxInt64`.
+
+## Test Gotchas
+
+- Tests use global Sentry state through `sentry.Init`, `sentry.CurrentHub()`, and `sentry.Flush`; avoid adding parallel tests unless you isolate/reset that state.
+- The test transport is an in-memory `transportMock`; no real DSN or network service is required.
+- Random values come from `gofakeit`; assertions should find logs by message instead of relying on event order.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/sentry-zapcore-skill/spec.md
+++ b/openspec/specs/sentry-zapcore-skill/spec.md
@@ -1,0 +1,84 @@
+# sentry-zapcore-skill Specification
+
+## Purpose
+
+Provide an agent skill that guides integrating Zap logging with Sentry in Go using `github.com/adlandh/sentry-zapcore/v2`, covering installation, Sentry initialization, logger attachment, configuration, tracing, flush semantics, and known gotchas.
+
+## Requirements
+
+### Requirement: Skill directory and file layout
+
+The repository SHALL contain a top-level `skills/` directory, and the skill SHALL live at `skills/sentry-zapcore/SKILL.md` with valid frontmatter.
+
+#### Scenario: Skill file exists with frontmatter
+
+- **WHEN** an agent reads `skills/sentry-zapcore/SKILL.md`
+- **THEN** the file exists and begins with YAML frontmatter containing a `name` of `sentry-zapcore` and a `description` that triggers on integrating Zap logging with Sentry in Go
+
+### Requirement: Installation and import guidance
+
+The skill SHALL document installing the module and the correct import path/alias.
+
+#### Scenario: Install and import shown
+
+- **WHEN** an agent follows the skill to add the dependency
+- **THEN** it uses `go get github.com/adlandh/sentry-zapcore/v2` and imports it as `sentryzapcore "github.com/adlandh/sentry-zapcore/v2"`
+
+### Requirement: Sentry initialization prerequisite
+
+The skill SHALL state that `sentry.Init` must run before wrapping a logger and that `EnableLogs: true` is required for log entries to reach Sentry.
+
+#### Scenario: Init prerequisite documented
+
+- **WHEN** an agent sets up the integration from the skill
+- **THEN** it calls `sentry.Init` with `EnableLogs: true` before creating or wrapping the Zap logger
+
+### Requirement: Attaching Sentry to a Zap logger
+
+The skill SHALL document both attachment paths: `WithSentryOption()` passed to a logger constructor, and `WithSentry(logger, ...)` to wrap an existing logger.
+
+#### Scenario: New logger with option
+
+- **WHEN** an agent creates a logger via `zap.NewProduction`/`zap.NewDevelopment`
+- **THEN** it passes `sentryzapcore.WithSentryOption(...)` as a `zap.Option`
+
+#### Scenario: Wrap existing logger
+
+- **WHEN** an agent already holds a `*zap.Logger`
+- **THEN** it reassigns it with `sentryzapcore.WithSentry(logger, ...)`
+
+### Requirement: Configuration options
+
+The skill SHALL document `WithMinLevel(level)` and `WithStackTrace()`, including the default threshold.
+
+#### Scenario: Default and overridden threshold
+
+- **WHEN** an agent reads the options section
+- **THEN** it learns the default sends only `ErrorLevel` and above, that `WithMinLevel(zapcore.InfoLevel)` lowers the threshold, and that `WithStackTrace()` adds stack traces for error-level entries
+
+### Requirement: Tracing integration via span context field
+
+The skill SHALL document passing Sentry span context as a `zapcore.SkipType` field whose `Interface` holds a non-nil `context.Context`.
+
+#### Scenario: Span context field shown
+
+- **WHEN** an agent wants Sentry tracing context on a log entry
+- **THEN** it builds a `zap.Field{Key:"ctx", Type:zapcore.SkipType, Interface: span.Context()}` and passes it to the log call
+
+### Requirement: Flush semantics
+
+The skill SHALL document calling `logger.Sync()` before process exit to flush buffered Sentry events and note the 2-second flush timeout.
+
+#### Scenario: Sync before exit
+
+- **WHEN** an agent finalizes a program using the integration
+- **THEN** it defers `logger.Sync()` and understands that Sync calls `sentry.Flush` with a 2-second timeout
+
+### Requirement: Documented gotchas
+
+The skill SHALL list known gotchas: levels above Error (DPanic/Panic/Fatal) collapse to Sentry Error, and tests/usage rely on global Sentry state.
+
+#### Scenario: Gotchas present
+
+- **WHEN** an agent reads the skill
+- **THEN** it sees that Error/DPanic/Panic/Fatal all map to Sentry Error and that Sentry state is global (init/flush affect the whole process)

--- a/skills/sentry-zapcore/SKILL.md
+++ b/skills/sentry-zapcore/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: sentry-zapcore
+description: >-
+  Use github.com/adlandh/sentry-zapcore/v2 to tee Zap structured logs into
+  Sentry. Apply when adding Sentry error/log reporting to a Go zap.Logger,
+  forwarding zap fields as Sentry attributes, attaching Sentry span/trace
+  context to logs, or configuring which zap levels reach Sentry.
+---
+
+# sentry-zapcore
+
+`github.com/adlandh/sentry-zapcore/v2` provides a `zapcore.Core` that tees Zap
+log entries into Sentry via Sentry's native `sentry.Logger`. You keep using Zap
+normally; error-level entries (by default) also land in Sentry with structured
+fields as attributes.
+
+Public API (package `sentryzapcore`): `WithSentry`, `WithSentryOption`,
+`NewSentryCore`, `WithMinLevel`, `WithStackTrace`.
+
+## Install & import
+
+```bash
+go get github.com/adlandh/sentry-zapcore/v2
+```
+
+```go
+import (
+    sentryzapcore "github.com/adlandh/sentry-zapcore/v2"
+    "github.com/getsentry/sentry-go"
+    "go.uber.org/zap"
+    "go.uber.org/zap/zapcore"
+)
+```
+
+Requires Go 1.25+, `go.uber.org/zap`, and `github.com/getsentry/sentry-go`.
+
+## Prerequisite: init Sentry first
+
+`sentry.Init` MUST run before wrapping the logger, and `EnableLogs: true` is
+required — without it, entries never reach Sentry.
+
+```go
+err := sentry.Init(sentry.ClientOptions{
+    Dsn:         "your-sentry-dsn",
+    Environment: "production",
+    EnableLogs:  true,
+})
+if err != nil {
+    panic(err)
+}
+```
+
+## Attach Sentry to a Zap logger
+
+Two paths. Pick one.
+
+**New logger** — pass `WithSentryOption()` as a `zap.Option` to any constructor:
+
+```go
+logger, err := zap.NewProduction(sentryzapcore.WithSentryOption())
+if err != nil {
+    panic(err)
+}
+defer func() { _ = logger.Sync() }()
+```
+
+**Existing logger** — wrap it and reassign:
+
+```go
+logger = sentryzapcore.WithSentry(logger)
+defer func() { _ = logger.Sync() }()
+```
+
+Both accept the same `SentryCoreOptions` variadic.
+
+## Configuration options
+
+Default threshold: only `zapcore.ErrorLevel` and above go to Sentry.
+
+```go
+// Lower threshold (e.g. Info and above)
+logger = sentryzapcore.WithSentry(logger, sentryzapcore.WithMinLevel(zapcore.InfoLevel))
+
+// Include stack traces for error-level entries
+logger = sentryzapcore.WithSentry(logger, sentryzapcore.WithStackTrace())
+
+// Combine
+logger = sentryzapcore.WithSentry(logger,
+    sentryzapcore.WithMinLevel(zapcore.WarnLevel),
+    sentryzapcore.WithStackTrace(),
+)
+```
+
+- `WithMinLevel(level)` — minimum level forwarded to Sentry; below it is dropped.
+- `WithStackTrace()` — adds a `stacktrace` attribute for entries at Error+.
+
+## Structured fields → Sentry attributes
+
+Zap fields on an entry become Sentry attributes automatically:
+
+```go
+logger.Error("Something went wrong",
+    zap.String("user_id", "123"),
+    zap.Int("status_code", 500),
+    zap.Error(err),
+)
+```
+
+Conversion notes: `time.Time` → RFC3339Nano string, `time.Duration` → string,
+`[]byte` → string, `error`/`fmt.Stringer` → its string, `uint64` values above
+`math.MaxInt64` → string; unknown types → `fmt.Sprint`.
+
+## Tracing: attach Sentry span context
+
+Pass span context as a special `zapcore.SkipType` field whose `Interface` holds
+a non-nil `context.Context`. It is consumed as span context, not emitted as a
+normal attribute.
+
+```go
+span := sentry.StartSpan(ctx, "operation_name")
+defer span.Finish()
+
+ctxField := zap.Field{
+    Key:       "ctx",
+    Type:      zapcore.SkipType,
+    Interface: span.Context(),
+}
+
+logger.Error("Error during operation", ctxField, zap.Error(err))
+```
+
+## Flush before exit
+
+`Sync()` flushes buffered Sentry events via `sentry.Flush` with a 2-second
+timeout; on timeout it returns an error. Always defer it before process exit:
+
+```go
+defer func() { _ = logger.Sync() }()
+```
+
+## Gotchas
+
+- **Levels above Error collapse**: Error, DPanic, Panic, Fatal all map to Sentry
+  `Error`. Sentry logs have no separate panic/fatal channel.
+- **Global Sentry state**: `sentry.Init`, `CurrentHub()`, and `sentry.Flush`
+  are process-global. Init once; Sync flushes the whole process. Avoid parallel
+  tests unless you isolate/reset Sentry state.
+- **`EnableLogs: true` is mandatory** — easy to forget; logs silently go nowhere
+  without it.
+- **`example` dir is singular** in this repo (not `examples`); the lint config's
+  `examples$` exclude does not match it locally.


### PR DESCRIPTION
## What

Adds `skills/sentry-zapcore/SKILL.md` — an agent skill that teaches correct usage of this library so AI coding agents don't re-derive the API from source each time.

Skill covers:
- Install & import (`go get .../v2`, alias `sentryzapcore`)
- Sentry init prerequisite (`EnableLogs: true` mandatory)
- Both attach paths: `WithSentryOption()` (constructor) and `WithSentry(logger, ...)` (existing logger)
- Options: default `ErrorLevel` threshold, `WithMinLevel`, `WithStackTrace`
- Structured fields → Sentry attributes (with conversion notes)
- Tracing: span context via `zapcore.SkipType` field
- Flush via `Sync()` (2s `sentry.Flush` timeout)
- Gotchas: Error/DPanic/Panic/Fatal collapse to Sentry Error; global Sentry state

Also bootstraps OpenSpec planning: `openspec/config.yaml`, synced spec for the `sentry-zapcore-skill` capability, `AGENTS.md`, and `.gitignore` entries (incl. `openspec/changes/archive`).

## Why

Packaged, in-repo skill keeps usage guidance accurate and co-located with the code it documents.

## Notes for reviewer

- No library source or public API changes; docs/tooling only.
- All API symbols in the skill cross-checked against `logger.go`, `options.go`, `sentry.go`, `sentry_convert.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)