### PR TITLE
docs: mark project as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Sentry Zap Core
 
+> [!WARNING]
+> **This project is no longer maintained.** Please use the official Sentry Zap integration instead: [`github.com/getsentry/sentry-go/zap`](https://pkg.go.dev/github.com/getsentry/sentry-go/zap).
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/adlandh/sentry-zapcore/v2.svg)](https://pkg.go.dev/github.com/adlandh/sentry-zapcore/v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/adlandh/sentry-zapcore/v2)](https://goreportcard.com/report/github.com/adlandh/sentry-zapcore/v2)
 


### PR DESCRIPTION
## What

Adds a deprecation warning to the top of the README marking this project as no longer maintained, and directs users to the official Sentry Zap integration: [`github.com/getsentry/sentry-go/zap`](https://pkg.go.dev/github.com/getsentry/sentry-go/zap).

## Why

Sentry now ships an official Zap integration, which supersedes this library. Users should be steered to the maintained option.

## Notes

Documentation-only change. No code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)